### PR TITLE
Added CLI support for file path input

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -18,7 +18,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget *parent = nullptr);
+    explicit MainWindow(QWidget *parent = nullptr, const QString &filePath = "");
     ~MainWindow();
 
 private slots:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,12 @@
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
-    MainWindow w;
+    QString filePath;
+    QStringList arguments = QCoreApplication::arguments();
+    if (arguments.size() > 1) {
+        filePath = arguments.at(1);
+    }
+    MainWindow w(nullptr, filePath);
 
     a.setStyle("fusion");
     w.show();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,7 +11,7 @@
 #include "dlgsymbinfo.h"
 #include "psfutil.h"
 
-MainWindow::MainWindow(QWidget *parent) :
+MainWindow::MainWindow(QWidget *parent, const QString &filePath) :
     QMainWindow(parent),
     selectedFilter(""),
     ui(new Ui::MainWindow)
@@ -20,6 +20,27 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->listFontGlyphs->setItemDelegate(new QGlyphListWidgetItemDelegate);
     fileModified = false;
     connect(ui->widgetGlyphEditor, &QFontGlyphEditor::glyphChanged, this, &MainWindow::on_glyphChanged);
+
+    if (!filePath.isEmpty()) {
+      QFileInfo fi(filePath);
+      if (fi.exists()) {
+          currentFile.setFileName(filePath);
+
+          QString extension = fi.suffix().toLower();
+          if (extension == "psf") {
+              selectedFilter = "PSF file (*.psf)";
+          } else if (extension == "mif") {
+              selectedFilter = "Verilog MIF (*.mif)";
+          } else {
+              QMessageBox::warning(this, "Error", "Unsupported file type: " + extension);
+              return;
+          }
+
+          on_actionOpenFontFile_triggered();
+      } else {
+          QMessageBox::warning(this, "Error", "File does not exist: " + filePath);
+      }
+  }
 }
 
 MainWindow::~MainWindow() {


### PR DESCRIPTION
This is a proposal to add support for specifying the file path via CLI.

In my use case, the target file is often located in the current directory or within the Nix store path, which can result in significantly longer paths. Additionally, locating the file from $HOME using the GUI can sometimes feel inconvenient.

To make this workflow smoother, I added an option to specify the file path directly via CLI.
I have tested this change with both absolute and relative paths, and it works as expected.